### PR TITLE
Send Post Request to match-decisions servlet

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 const NO_MATCH =  "NO_POTENTIAL_MATCHES"; // must be kept in sync with the PotentialMatches.java servlet
+const FRIENDED = "FRIENDED";
+const PASSED = "PASSED";
+let currentPMDisplayed;
  
 // Function that is called onLoad of the body tag
 function initializeProfilePage() {
@@ -134,6 +137,7 @@ function getNextPotentialMatch() {
       document.getElementById("pass-btn").disabled = false;
       document.getElementById("friend-btn").disabled = false;
       displayPotentialMatchInfo(pmID.nextPotentialMatchID);
+      currentPMdisplayed = pmID.nextPotentialMatchID;
   }); 
 }
 
@@ -146,13 +150,25 @@ function noPotentialMatch() {
 }
 
 function matchButtonPressed() {
-  // TODO: send match info to matching servlet
-  getNextPotentialMatch();  
+  const decision = {
+      userid: getCurrentUserId(),
+      potentialMatchID: currentPMDisplayed,
+      decision: FRIENDED
+  }
+  fetch('/match-decisions', {method: 'POST', body: JSON.stringify(decision)}).then((response) => {
+      getNextPotentialMatch();
+  });
 }
 
 function passButtonPressed() {
-  // TODO: send pass info to matching servlet
-  getNextPotentialMatch();
+  const decision = {
+      userid: getCurrentUserId(),
+      potentialMatchID: currentPMDisplayed,
+      decision: PASSED
+  }
+  fetch('/match-decisions', {method: 'POST', body: JSON.stringify(decision)}).then((response) => {
+      getNextPotentialMatch();
+  });
 }
 
 function loadProfile() {

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -155,7 +155,7 @@ function matchButtonPressed() {
       potentialMatchID: currentPMDisplayed,
       decision: FRIENDED
   }
-  fetch('/match-decisions', {method: 'POST', body: JSON.stringify(decision)}).then((response) => {
+  fetch('/match-decisions', { method: 'POST', body: JSON.stringify(decision) }).then((response) => {
       getNextPotentialMatch();
   });
 }
@@ -166,7 +166,7 @@ function passButtonPressed() {
       potentialMatchID: currentPMDisplayed,
       decision: PASSED
   }
-  fetch('/match-decisions', {method: 'POST', body: JSON.stringify(decision)}).then((response) => {
+  fetch('/match-decisions', { method: 'POST', body: JSON.stringify(decision) }).then((response) => {
       getNextPotentialMatch();
   });
 }


### PR DESCRIPTION
### What is a quick description of the change?

when the user clicks the friend me or pass button, a post request is sent to the match-decisions servlet with the current user id, the potential match id, and the match decision, i.e whether the user clicked friend me or pass. 
### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [  ] Test written/updating
- [ x ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.
passing manual tests

### Any additional comments?
