### PR TITLE
Add servlet to retrieve matches

### DIFF
--- a/src/main/java/com/google/sps/servlets/MatchesListServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchesListServlet.java
@@ -44,7 +44,6 @@ public class MatchesListServlet extends HttpServlet {
   private static final String FRIENDED_IDS_PROPERTY = "friended-ids";
   private static final String PASSED_IDS_PROPERTY = "passed-ids";
   private static final String MATCHES_LIST_PROPERTY = "matches-list";
-
   private static final String USER_ID_REQUEST_URL_PARAM = "userid";
   
   DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/src/main/java/com/google/sps/servlets/MatchesListServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchesListServlet.java
@@ -1,0 +1,71 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.gson.Gson;
+import com.google.common.collect.ImmutableList;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Entity;
+
+/**
+ * Servlet that handles requests to retrieve a list of a user's matches
+ */
+@WebServlet("/match-information")
+public class MatchesListServlet extends HttpServlet {
+  private static final String MATCH_INFO_ENTITY = "match-info";
+  private static final String USER_ID_PROPERTY = "id";
+  private static final String POTENTIAL_MATCHES_PROPERTY = "potential-matches";
+  private static final String FRIENDED_IDS_PROPERTY = "friended-ids";
+  private static final String PASSED_IDS_PROPERTY = "passed-ids";
+  private static final String MATCHES_LIST_PROPERTY = "matches-list";
+
+  private static final String USER_ID_REQUEST_URL_PARAM = "userid";
+  
+  DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String userID = (String) request.getParameter(USER_ID_REQUEST_URL_PARAM);
+    
+    Entity matchInfoEntity = datastore.prepare(new Query(MATCH_INFO_ENTITY).setFilter(
+      new FilterPredicate(USER_ID_PROPERTY, FilterOperator.EQUAL, userID))).asSingleEntity();
+
+    List<String> matchedUsers = (List<String>) matchInfoEntity.getProperty(MATCHES_LIST_PROPERTY);
+    if (matchedUsers == null) {
+      matchedUsers = Arrays.asList();
+    }
+
+    Gson gson = new Gson();
+    String json = gson.toJson(matchedUsers);
+
+    response.setContentType("application/json");
+    response.getWriter().print(json);
+  }
+}
+

--- a/src/main/java/com/google/sps/servlets/MatchesListServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchesListServlet.java
@@ -36,7 +36,7 @@ import com.google.appengine.api.datastore.Entity;
 /**
  * Servlet that handles requests to retrieve a list of a user's matches
  */
-@WebServlet("/match-information")
+@WebServlet("/matches-list")
 public class MatchesListServlet extends HttpServlet {
   private static final String MATCH_INFO_ENTITY = "match-info";
   private static final String USER_ID_PROPERTY = "id";

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -99,11 +99,10 @@ public class MatchesListServletTest {
     addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
       ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
     
-    String actualOutput = execute(TEST_USER_ID);
-    
-    List<String> actualOutputAsList = Arrays.asList(new Gson().fromJson(actualOutput, String[].class));
+    String jsonOutput = execute(TEST_USER_ID);
+    List<String> matches = Arrays.asList(new Gson().fromJson(jsonOutput, String[].class));
 
-    assertThat(actualOutputAsList).isEqualTo(EMPTY_LIST);
+    assertThat(matches).isEmpty();
   }
 
   /**
@@ -116,11 +115,10 @@ public class MatchesListServletTest {
     addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
       ImmutableList.of(), ImmutableList.of(), ImmutableList.of(TEST_CONNECTION_1_ID));
     
-    String actualOutput = execute(TEST_USER_ID);
-    
-    List<String> actualOutputAsList = Arrays.asList(new Gson().fromJson(actualOutput, String[].class));
+    String jsonOutput = execute(TEST_USER_ID);
+    List<String> matches = Arrays.asList(new Gson().fromJson(jsonOutput, String[].class));
 
-    assertThat(actualOutputAsList).containsExactly(TEST_CONNECTION_1_ID);
+    assertThat(matches).containsExactly(TEST_CONNECTION_1_ID);
   }
   
   /**
@@ -133,11 +131,10 @@ public class MatchesListServletTest {
     addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(),
     ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID));
     
-    String actualOutput = execute(TEST_USER_ID);
-    
-    List<String> actualOutputAsList = Arrays.asList(new Gson().fromJson(actualOutput, String[].class));
+    String jsonOutput = execute(TEST_USER_ID);
+    List<String> matches = Arrays.asList(new Gson().fromJson(jsonOutput, String[].class));
 
-    assertThat(actualOutputAsList).containsExactly(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID);
+    assertThat(matches).containsExactly(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID);
   }
 
   /**

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -87,13 +87,8 @@ public class MatchesListServletTest {
     helper.tearDown();
   }
 
-  /**
-   * Tests the case in which a user's match list is empty.
-   *
-   * <p>Should return an empty list.
-   */
   @Test
-  public void matchInfoWithEmptyList() throws Exception {
+  public void hasNoMatches() throws Exception {
     addMatchInfoEntityToDatastore(TEST_USER_ID, /* friendedUsers= */ ImmutableList.of(),
       /* matchedUsers= */ImmutableList.of());
     
@@ -103,13 +98,8 @@ public class MatchesListServletTest {
     assertThat(matches).isEmpty();
   }
 
-  /**
-   * Tests the case where a user has one match in their match list
-   *
-   * <p>Should return a list with just that one match's id
-   */
   @Test
-  public void matchInfoWithSingleMatch() throws Exception {
+  public void hasSingleMatch() throws Exception {
     addMatchInfoEntityToDatastore(TEST_USER_ID, /* friendedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID),
       /* matchedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID));
     
@@ -119,13 +109,8 @@ public class MatchesListServletTest {
     assertThat(matches).containsExactly(TEST_CONNECTION_1_ID);
   }
   
-  /**
-   * Tests the case where a user has three matches in their match list
-   *
-   * <p> Should a return a list with the three matches' ids
-   */
   @Test
-  public void matchInfoWithMultipleMatches() throws Exception {
+  public void hasMultipleMatches() throws Exception {
     addMatchInfoEntityToDatastore(TEST_USER_ID, /* friendedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID),
       /* matchedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID));
     

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -95,7 +95,7 @@ public class MatchesListServletTest {
    * <p>Should return an empty list.
    */
   @Test
-  public void matchInfoWithEmptyList() throws IOException{
+  public void matchInfoWithEmptyList() throws Exception {
     addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
       ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
     
@@ -111,7 +111,7 @@ public class MatchesListServletTest {
    * <p>Should return a list with just that one match's id
    */
   @Test
-  public void matchInfoWithSingleMatch() throws IOException{
+  public void matchInfoWithSingleMatch() throws Exception {
     addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
       ImmutableList.of(), ImmutableList.of(), ImmutableList.of(TEST_CONNECTION_1_ID));
     
@@ -127,7 +127,7 @@ public class MatchesListServletTest {
    * <p> Should a return a list with the three matches' ids
    */
   @Test
-  public void matchInfoWithMultipleMatches() throws IOException{
+  public void matchInfoWithMultipleMatches() throws Exception {
     addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(),
     ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID));
     

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -58,8 +58,6 @@ public class MatchesListServletTest {
   private static final String TEST_CONNECTION_2_ID = "1234";
   private static final String TEST_CONNECTION_3_ID = "9876";
 
-  private static final List<String> EMPTY_LIST = Arrays.asList();
-
   private final LocalServiceTestHelper helper =
     new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
@@ -143,22 +141,19 @@ public class MatchesListServletTest {
    *
    * @param userIDToFetch The ID of the user whose next potential match is being found
    */
-  private String execute(String userIDToFetch) throws IOException{
+  private String execute(String userIDToFetch) throws IOException {
     when(mockRequest.getParameter(USER_ID_REQUEST_URL_PARAM)).thenReturn(userIDToFetch);
-    
     responseWriter = new StringWriter();
     writer = new PrintWriter(responseWriter, true);
     when(mockResponse.getWriter()).thenReturn(writer);
 
     servletUnderTest.doGet(mockRequest, mockResponse);
-    System.out.println(responseWriter);
     
     return responseWriter.toString();
   }
 
   private void addMatchInfoEntityToDatastore(String userID, ImmutableList<String> potentialMatches, 
     ImmutableList<String> friendedUsers, ImmutableList<String> passedUsers, ImmutableList<String> matchedUsers) {
-    
     Entity newMatchInfoEntity = new Entity(MATCH_INFO_ENTITY);
     newMatchInfoEntity.setProperty(USER_ID_PROPERTY, userID);
     newMatchInfoEntity.setProperty(POTENTIAL_MATCHES_PROPERTY, potentialMatches);

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -1,0 +1,174 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.json.JSONObject;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Arrays;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.junit.After;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+
+@RunWith(JUnit4.class)
+public class MatchesListServletTest {
+  private static final String MATCH_INFO_ENTITY = "match-info";
+  private static final String USER_ID_PROPERTY = "id";
+  private static final String POTENTIAL_MATCHES_PROPERTY = "potential-matches";
+  private static final String FRIENDED_IDS_PROPERTY = "friended-ids";
+  private static final String PASSED_IDS_PROPERTY = "passed-ids";
+  private static final String MATCHES_LIST_PROPERTY = "matches-list";
+
+  private static final String USER_ID_REQUEST_URL_PARAM = "userid";
+
+  private static final String TEST_USER_ID = "5555";
+  private static final String TEST_CONNECTION_1_ID = "1776";
+  private static final String TEST_CONNECTION_2_ID = "1234";
+  private static final String TEST_CONNECTION_3_ID = "9876";
+
+  private static final List<String> EMPTY_LIST = Arrays.asList();
+
+  private final LocalServiceTestHelper helper =
+    new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Mock
+  private HttpServletRequest mockRequest;
+ 
+  @Mock
+  private HttpServletResponse mockResponse;
+
+  private MatchesListServlet servletUnderTest;
+  private DatastoreService datastore;
+  private StringWriter responseWriter;
+  private PrintWriter writer;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+
+    helper.setUp();
+
+    servletUnderTest = new MatchesListServlet();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  /**
+   * Tests the case in which a user's match list is empty.
+   *
+   * <p>Should return an empty list.
+   */
+  @Test
+  public void matchInfoWithEmptyList() throws IOException{
+    addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
+      ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+    
+    String actualOutput = execute(TEST_USER_ID);
+    
+    List<String> actualOutputAsList = Arrays.asList(new Gson().fromJson(actualOutput, String[].class));
+
+    assertThat(actualOutputAsList).isEqualTo(EMPTY_LIST);
+  }
+
+  /**
+   * Tests the case where a user has one match in their match list
+   *
+   * <p>Should return a list with just that one match's id
+   */
+  @Test
+  public void matchInfoWithSingleMatch() throws IOException{
+    addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
+      ImmutableList.of(), ImmutableList.of(), ImmutableList.of(TEST_CONNECTION_1_ID));
+    
+    String actualOutput = execute(TEST_USER_ID);
+    
+    List<String> actualOutputAsList = Arrays.asList(new Gson().fromJson(actualOutput, String[].class));
+
+    assertThat(actualOutputAsList).containsExactly(TEST_CONNECTION_1_ID);
+  }
+  
+  /**
+   * Tests the case where a user has three matches in their match list
+   *
+   * <p> Should a return a list with the three matches' ids
+   */
+  @Test
+  public void matchInfoWithMultipleMatches() throws IOException{
+    addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(),
+    ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID));
+    
+    String actualOutput = execute(TEST_USER_ID);
+    
+    List<String> actualOutputAsList = Arrays.asList(new Gson().fromJson(actualOutput, String[].class));
+
+    assertThat(actualOutputAsList).containsExactly(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID);
+  }
+
+  /**
+   * Method that calls on the MatchInformationServlet and returns the ID of the next
+   * potential match for the specified user
+   *
+   * @param userIDToFetch The ID of the user whose next potential match is being found
+   */
+  private String execute(String userIDToFetch) throws IOException{
+    when(mockRequest.getParameter(USER_ID_REQUEST_URL_PARAM)).thenReturn(userIDToFetch);
+    
+    responseWriter = new StringWriter();
+    writer = new PrintWriter(responseWriter, true);
+    when(mockResponse.getWriter()).thenReturn(writer);
+
+    servletUnderTest.doGet(mockRequest, mockResponse);
+    System.out.println(responseWriter);
+    
+    return responseWriter.toString();
+  }
+
+  private void addMatchInfoEntityToDatastore(String userID, ImmutableList<String> potentialMatches, 
+    ImmutableList<String> friendedUsers, ImmutableList<String> passedUsers, ImmutableList<String> matchedUsers) {
+    
+    Entity newMatchInfoEntity = new Entity(MATCH_INFO_ENTITY);
+    newMatchInfoEntity.setProperty(USER_ID_PROPERTY, userID);
+    newMatchInfoEntity.setProperty(POTENTIAL_MATCHES_PROPERTY, potentialMatches);
+    newMatchInfoEntity.setProperty(FRIENDED_IDS_PROPERTY, friendedUsers);
+    newMatchInfoEntity.setProperty(PASSED_IDS_PROPERTY, passedUsers);
+    newMatchInfoEntity.setProperty(MATCHES_LIST_PROPERTY, matchedUsers);
+    datastore.put(newMatchInfoEntity);
+  }
+}
+

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -50,9 +50,9 @@ public class MatchesListServletTest {
   private static final String FRIENDED_IDS_PROPERTY = "friended-ids";
   private static final String PASSED_IDS_PROPERTY = "passed-ids";
   private static final String MATCHES_LIST_PROPERTY = "matches-list";
-
   private static final String USER_ID_REQUEST_URL_PARAM = "userid";
 
+  //Test user ids
   private static final String TEST_USER_ID = "5555";
   private static final String TEST_CONNECTION_1_ID = "1776";
   private static final String TEST_CONNECTION_2_ID = "1234";

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -121,10 +121,9 @@ public class MatchesListServletTest {
   }
 
   /**
-   * Method that calls on the MatchInformationServlet and returns the ID of the next
-   * potential match for the specified user
+   * Method that calls on the MatchInformationServlet and returns the specified user's matches
    *
-   * @param userIDToFetch The ID of the user whose next potential match is being found
+   * @param userIDToFetch The ID of the user whose matches are being found
    * @return The response from the get request to MatchInformationServlet as a string
    */
   private String execute(String userIDToFetch) throws IOException {

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -140,6 +140,7 @@ public class MatchesListServletTest {
    * potential match for the specified user
    *
    * @param userIDToFetch The ID of the user whose next potential match is being found
+   * @return The response from the get request to MatchInformationServlet as a string
    */
   private String execute(String userIDToFetch) throws IOException {
     when(mockRequest.getParameter(USER_ID_REQUEST_URL_PARAM)).thenReturn(userIDToFetch);

--- a/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchesListServletTest.java
@@ -94,8 +94,8 @@ public class MatchesListServletTest {
    */
   @Test
   public void matchInfoWithEmptyList() throws Exception {
-    addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
-      ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+    addMatchInfoEntityToDatastore(TEST_USER_ID, /* friendedUsers= */ ImmutableList.of(),
+      /* matchedUsers= */ImmutableList.of());
     
     String jsonOutput = execute(TEST_USER_ID);
     List<String> matches = Arrays.asList(new Gson().fromJson(jsonOutput, String[].class));
@@ -110,8 +110,8 @@ public class MatchesListServletTest {
    */
   @Test
   public void matchInfoWithSingleMatch() throws Exception {
-    addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(),
-      ImmutableList.of(), ImmutableList.of(), ImmutableList.of(TEST_CONNECTION_1_ID));
+    addMatchInfoEntityToDatastore(TEST_USER_ID, /* friendedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID),
+      /* matchedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID));
     
     String jsonOutput = execute(TEST_USER_ID);
     List<String> matches = Arrays.asList(new Gson().fromJson(jsonOutput, String[].class));
@@ -126,8 +126,8 @@ public class MatchesListServletTest {
    */
   @Test
   public void matchInfoWithMultipleMatches() throws Exception {
-    addMatchInfoEntityToDatastore(TEST_USER_ID, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(),
-    ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID));
+    addMatchInfoEntityToDatastore(TEST_USER_ID, /* friendedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID),
+      /* matchedUsers= */ ImmutableList.of(TEST_CONNECTION_1_ID, TEST_CONNECTION_2_ID, TEST_CONNECTION_3_ID));
     
     String jsonOutput = execute(TEST_USER_ID);
     List<String> matches = Arrays.asList(new Gson().fromJson(jsonOutput, String[].class));
@@ -152,14 +152,13 @@ public class MatchesListServletTest {
     return responseWriter.toString();
   }
 
-  private void addMatchInfoEntityToDatastore(String userID, ImmutableList<String> potentialMatches, 
-    ImmutableList<String> friendedUsers, ImmutableList<String> passedUsers, ImmutableList<String> matchedUsers) {
+  private void addMatchInfoEntityToDatastore(String userID, ImmutableList<String> friendedUsers, ImmutableList<String> matchedUsers) {
     Entity newMatchInfoEntity = new Entity(MATCH_INFO_ENTITY);
     newMatchInfoEntity.setProperty(USER_ID_PROPERTY, userID);
-    newMatchInfoEntity.setProperty(POTENTIAL_MATCHES_PROPERTY, potentialMatches);
     newMatchInfoEntity.setProperty(FRIENDED_IDS_PROPERTY, friendedUsers);
-    newMatchInfoEntity.setProperty(PASSED_IDS_PROPERTY, passedUsers);
     newMatchInfoEntity.setProperty(MATCHES_LIST_PROPERTY, matchedUsers);
+    newMatchInfoEntity.setProperty(POTENTIAL_MATCHES_PROPERTY, ImmutableList.of());
+    newMatchInfoEntity.setProperty(PASSED_IDS_PROPERTY, ImmutableList.of());
     datastore.put(newMatchInfoEntity);
   }
 }


### PR DESCRIPTION
### What is a quick description of the change?

- Add a servlet that returns the list of a user's current matches

- Add test cases to test the functionality of the matches servlet

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [ x ] Test written/updating
- [ x ] Tests passing
- [ x ] Coding style (indentation, etc)

