### PR TITLE
Add facebook profile links to user datastore

### DIFF
--- a/src/main/java/com/google/sps/servlets/UserDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserDataServlet.java
@@ -61,6 +61,7 @@ public class UserDataServlet extends HttpServlet {
   static final String USER_FOUND_PROPERTY = "user-found";
   static final String USER_FRIENDS_LIST_PROPERTY = "friends-list";
   static final String USER_ID_PROPERTY = "id";
+  static final String USER_LINK_PROPERTY = "link";
   static final String USER_NAME_PROPERTY = "name";
   static final String USER_PHOTO_1_PROPERTY = "profile-photo";
   static final String USER_PHOTO_2_PROPERTY = "photo-2";
@@ -94,6 +95,7 @@ public class UserDataServlet extends HttpServlet {
           .put(USER_EMAIL_PROPERTY, userEntity.getProperty(USER_EMAIL_PROPERTY))
           .put(USER_FRIENDS_LIST_PROPERTY, (ArrayList<String>) userEntity.getProperty(USER_FRIENDS_LIST_PROPERTY))
           .put(USER_ID_PROPERTY, userEntity.getProperty(USER_ID_PROPERTY))
+          .put(USER_LINK_PROPERTY, userEntity.getProperty(USER_LINK_PROPERTY))
           .put(USER_NAME_PROPERTY, userEntity.getProperty(USER_NAME_PROPERTY))
           .put(USER_BLOBKEYS_PROPERTY, (ArrayList<String>) userEntity.getProperty(USER_BLOBKEYS_PROPERTY));
     }
@@ -110,6 +112,7 @@ public class UserDataServlet extends HttpServlet {
     String userName = getStringParameter(request, USER_NAME_PROPERTY, DEFAULT_STRING);
     String userEmail = getStringParameter(request, USER_EMAIL_PROPERTY, DEFAULT_STRING);
     String userBio = getStringParameter(request, USER_BIO_PROPERTY, DEFAULT_STRING);
+    String userLink = getStringParameter(request, USER_LINK_PROPERTY, DEFAULT_STRING);
     String[] friends = getStringArrayParameter(request, USER_FRIENDS_LIST_PROPERTY, new String[]{});
 
     // Check if a user entity with userId already exists
@@ -122,6 +125,7 @@ public class UserDataServlet extends HttpServlet {
       userEntity.setProperty(USER_NAME_PROPERTY, userName);
       userEntity.setProperty(USER_EMAIL_PROPERTY, userEmail);
       userEntity.setProperty(USER_BIO_PROPERTY, userBio);
+      userEntity.setProperty(USER_LINK_PROPERTY, userLink);
       userEntity.setProperty(USER_FRIENDS_LIST_PROPERTY, Arrays.asList(friends));
       userEntity.setProperty(USER_BLOBKEYS_PROPERTY, new ArrayList<>(Arrays.asList(new String[]{"", "", "", "", ""})));
     }
@@ -132,6 +136,7 @@ public class UserDataServlet extends HttpServlet {
       setPropertyIfNotDefault(userEntity, USER_NAME_PROPERTY, userName, DEFAULT_STRING);
       setPropertyIfNotDefault(userEntity, USER_EMAIL_PROPERTY, userEmail, DEFAULT_STRING);
       setPropertyIfNotDefault(userEntity, USER_BIO_PROPERTY, userBio, DEFAULT_STRING);
+      setPropertyIfNotDefault(userEntity, USER_LINK_PROPERTY, userLink, DEFAULT_STRING);
 
       // If the friends-list property wasn't given, don't override the current friends list
       if (friends.length != 0) {

--- a/src/main/webapp/facebook-login.js
+++ b/src/main/webapp/facebook-login.js
@@ -28,16 +28,16 @@ function statusChangeCallback(response) {
   if (response.status === 'connected') {
     // User is logged in with Facebook
     // TODO(#16): Redirect user to the correct page depending on whether their profile is complete.
-    // TODO(#18): Fix bug where facebook login only redirects upon page reload.
     // For now, redirect to the profile page
     // Query Facebook Graph API for user information
-    FB.api('/me?fields=id,name,email,friends', function(response) {
+    FB.api('/me?fields=id,name,email,friends,link', function(response) {
       let userInfo = new URLSearchParams({
         name: response.name,
         id: response.id,
         email: response.email,
+        link: response.link,
       });
- 
+
       // Add friend ids to the query string
       // TODO(#17): Consider replacing this with jquery + ajax to send JSON to the backend.
       response.friends.data.forEach((friend) => userInfo.append("friends-list", friend.id));

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -25,7 +25,7 @@
             <li class="nav-item">
                <div id="login" class="fb-login-button" data-size="large" data-button-type="continue_with"
                   data-layout="default" data-auto-logout-link="true" data-use-continue-as="false"
-                  data-scope="public_profile,email,user_friends">
+                  data-scope="public_profile,email,user_friends,user_link">
                </div>
             </li>
           </ul>

--- a/src/test/java/com/google/sps/servlets/UserDataServletTest.java
+++ b/src/test/java/com/google/sps/servlets/UserDataServletTest.java
@@ -58,6 +58,7 @@ public final class UserDataServletTest {
   private static final String TEST_USER_ID = "123";
   private static final String TEST_USER_EMAIL = "tim@gmail.com";
   private static final String TEST_USER_BIO = "Amazing!";
+  private static final String TEST_USER_LINK = "facebook.com/tim";
   private static final String[] TEST_USER_FRIENDS_LIST = new String[]{"321"};
   private static final String ALTERNATE_TEST_USER_NAME = "John";
   private static final String TEST_PHOTO_1_BLOBKEY = "abc";
@@ -319,6 +320,7 @@ public final class UserDataServletTest {
     userEntity.setProperty(UserDataServlet.USER_NAME_PROPERTY, TEST_USER_NAME);
     userEntity.setProperty(UserDataServlet.USER_EMAIL_PROPERTY, TEST_USER_EMAIL);
     userEntity.setProperty(UserDataServlet.USER_BIO_PROPERTY, TEST_USER_BIO);
+    userEntity.setProperty(UserDataServlet.USER_LINK_PROPERTY, TEST_USER_LINK);
     userEntity.setProperty(UserDataServlet.USER_FRIENDS_LIST_PROPERTY, Arrays.asList(TEST_USER_FRIENDS_LIST));
     userEntity.setProperty(UserDataServlet.USER_BLOBKEYS_PROPERTY, new ArrayList<>(Arrays.asList(new String[]{"", "", "", "", ""})));
     datastore.put(userEntity);


### PR DESCRIPTION
### What is a quick description of the change?

Add facebook profile links to datastore by fetching from the Facebook API with the correct `user_links` permission.

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [ ] Test written/updating
- [ ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.

Tests have already been written to cover both the doGet and doPost methods of the UserDataServlet

### Any additional comments?