### PR TITLE
Add the Facebook API permission to get a user's profile link

### DIFF
--- a/src/main/webapp/facebook-login.js
+++ b/src/main/webapp/facebook-login.js
@@ -62,6 +62,6 @@ function checkLoginState() {
 
 // Log the user into facebook with correct permissions
 function loginFacebook() {
-  FB.login(statusChangeCallback, {scope: 'email,public_profile,user_friends', return_scopes: true});
+  FB.login(statusChangeCallback, {scope: 'email,public_profile,user_friends,user_link', return_scopes: true});
 }
 


### PR DESCRIPTION
### What is a quick description of the change?

Add the permission for getting a user's profile link from the Facebook API.

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [  ] Test written/updating
- [  ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.

No test are necessary, one line of code changed.

### Any additional comments?