### PR TITLE
Potential matches servlet updates

### DIFF
--- a/src/main/java/com/google/sps/servlets/MatchDecisionsServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchDecisionsServlet.java
@@ -83,12 +83,13 @@ public class MatchDecisionsServlet extends HttpServlet {
   private void updateMatchDecisionInfo(Entity userMatchInfo, String decision, String potentialMatchID) {
     String decisionsProperty = decision.equals(FRIENDED_DECISION) ? FRIENDED_IDS_PROPERTY : PASSED_IDS_PROPERTY;
 
+    //update potential matches list
     List<String> potentialMatches = (List<String>) userMatchInfo.getProperty(POTENTIAL_MATCHES_PROPERTY);
     potentialMatches.remove(potentialMatchID);
-
     userMatchInfo.setProperty(POTENTIAL_MATCHES_PROPERTY,
         ImmutableList.copyOf(potentialMatches));
 
+    //update friended or passed list
     addItemToDatastoreList(userMatchInfo, decisionsProperty, potentialMatchID);
   }
 

--- a/src/main/java/com/google/sps/servlets/MatchDecisionsServlet.java
+++ b/src/main/java/com/google/sps/servlets/MatchDecisionsServlet.java
@@ -83,6 +83,12 @@ public class MatchDecisionsServlet extends HttpServlet {
   private void updateMatchDecisionInfo(Entity userMatchInfo, String decision, String potentialMatchID) {
     String decisionsProperty = decision.equals(FRIENDED_DECISION) ? FRIENDED_IDS_PROPERTY : PASSED_IDS_PROPERTY;
 
+    List<String> potentialMatches = (List<String>) userMatchInfo.getProperty(POTENTIAL_MATCHES_PROPERTY);
+    potentialMatches.remove(potentialMatchID);
+
+    userMatchInfo.setProperty(POTENTIAL_MATCHES_PROPERTY,
+        ImmutableList.copyOf(potentialMatches));
+
     addItemToDatastoreList(userMatchInfo, decisionsProperty, potentialMatchID);
   }
 

--- a/src/main/java/com/google/sps/servlets/PotentialMatchesServlet.java
+++ b/src/main/java/com/google/sps/servlets/PotentialMatchesServlet.java
@@ -90,8 +90,7 @@ public class PotentialMatchesServlet extends HttpServlet {
   }
   
   /**
-  * Given a specific user, retrieve their next potential match for their feed page
-  * and remove that potential match from their potential matches list
+  * Given a specific user, retrieve their next potential match for their feed page.
   *
   * @param userID The user whose potential match is being retrieved
   */
@@ -104,11 +103,6 @@ public class PotentialMatchesServlet extends HttpServlet {
     
     if (potentialMatches != null && !potentialMatches.isEmpty()) {
       nextPotentialMatchID = potentialMatches.get(0);
-
-      matchInfoEntity.setProperty(POTENTIAL_MATCHES_PROPERTY,
-        potentialMatches.subList(1, potentialMatches.size()));
-
-      datastore.put(matchInfoEntity);
     } else {
       nextPotentialMatchID = NO_POTENTIAL_MATCH_RESULT;
     }

--- a/src/test/java/com/google/sps/servlets/MatchDecisionsServletTest.java
+++ b/src/test/java/com/google/sps/servlets/MatchDecisionsServletTest.java
@@ -125,7 +125,7 @@ public class MatchDecisionsServletTest {
     List<String> resultingPotentialMatchesList = (List<String>) matchInfoEntity.getProperty(POTENTIAL_MATCHES_PROPERTY);
     
     assertThat(actualFriendedList).containsExactly(TEST_USER_2_ID);
-    assertThat(resultingPotentialMatchesList).isEqualTo(null);
+    assertThat(resultingPotentialMatchesList).isNull();
   }
 
   /**
@@ -156,7 +156,7 @@ public class MatchDecisionsServletTest {
     List<String> resultingPotentialMatchesList = (List<String>) matchInfoEntity.getProperty(POTENTIAL_MATCHES_PROPERTY);
 
     assertThat(actualPassedList).containsExactly(TEST_USER_2_ID);
-    assertThat(resultingPotentialMatchesList).isEqualTo(null);
+    assertThat(resultingPotentialMatchesList).isNull();
   }
 
   /**
@@ -186,7 +186,7 @@ public class MatchDecisionsServletTest {
     List<String> resultingPotentialMatchesList = (List<String>) matchInfoEntity.getProperty(POTENTIAL_MATCHES_PROPERTY);
 
     assertThat(actualFriendedList).containsExactly(TEST_USER_2_ID);
-    assertThat(resultingPotentialMatchesList).isEqualTo(null);     
+    assertThat(resultingPotentialMatchesList).isNull();     
   }
 
   /**
@@ -222,9 +222,9 @@ public class MatchDecisionsServletTest {
     List<String> resultingPotentialMatchesList2 = (List<String>) matchInfoEntity2.getProperty(POTENTIAL_MATCHES_PROPERTY);
 
     assertThat(actualMatchesList1).containsExactly(TEST_USER_2_ID);
-    assertThat(resultingPotentialMatchesList1).isEqualTo(null);  
+    assertThat(resultingPotentialMatchesList1).isNull();  
     assertThat(actualMatchesList2).containsExactly(TEST_USER_1_ID);
-    assertThat(resultingPotentialMatchesList2).isEqualTo(null);  
+    assertThat(resultingPotentialMatchesList2).isNull(); 
   }
 
   /**
@@ -259,9 +259,9 @@ public class MatchDecisionsServletTest {
     List<String> resultingPotentialMatchesList2 = (List<String>) matchInfoEntity1.getProperty(POTENTIAL_MATCHES_PROPERTY);
 
     assertThat(actualMatchesList1).isEqualTo(null);
-    assertThat(resultingPotentialMatchesList1).isEqualTo(null);  
+    assertThat(resultingPotentialMatchesList1).isNull();  
     assertThat(actualMatchesList2).isEqualTo(null);
-    assertThat(resultingPotentialMatchesList2).isEqualTo(null);  
+    assertThat(resultingPotentialMatchesList2).isNull(); 
   }
 
   /**
@@ -300,9 +300,9 @@ public class MatchDecisionsServletTest {
     List<String> resultingPotentialMatchesList2 = (List<String>) matchInfoEntity1.getProperty(POTENTIAL_MATCHES_PROPERTY);
 
     assertThat(actualMatchesList1).containsExactly(TEST_USER_2_ID, TEST_USER_3_ID);
-    assertThat(resultingPotentialMatchesList1).isEqualTo(null);  
+    assertThat(resultingPotentialMatchesList1).isNull(); 
     assertThat(actualMatchesList2).containsExactly(TEST_USER_1_ID);
-    assertThat(resultingPotentialMatchesList2).isEqualTo(null);  
+    assertThat(resultingPotentialMatchesList2).isNull(); 
   }
 
   /**
@@ -337,9 +337,9 @@ public class MatchDecisionsServletTest {
     List<String> actualMatchesList2 = (List<String>) matchInfoEntity2.getProperty(MATCHES_LIST_PROPERTY);
     List<String> resultingPotentialMatchesList2 = (List<String>) matchInfoEntity2.getProperty(POTENTIAL_MATCHES_PROPERTY);
 
-    assertThat(actualMatchesList1).isEqualTo(null);
+    assertThat(actualMatchesList1).isNull();
     assertThat(resultingPotentialMatchesList1).containsExactly(TEST_USER_3_ID);  
-    assertThat(actualMatchesList2).isEqualTo(null);
+    assertThat(actualMatchesList2).isNull();
     assertThat(resultingPotentialMatchesList2).containsExactly(TEST_USER_1_ID);   
   }
 
@@ -379,7 +379,7 @@ public class MatchDecisionsServletTest {
     assertThat(actualMatchesList1).containsExactly(TEST_USER_2_ID);
     assertThat(resultingPotentialMatchesList1).containsExactly(TEST_USER_3_ID, TEST_USER_4_ID);  
     assertThat(actualMatchesList2).containsExactly(TEST_USER_1_ID);
-    assertThat(resultingPotentialMatchesList2).isEqualTo(null); 
+    assertThat(resultingPotentialMatchesList2).isNull();
   }
 
   /**

--- a/src/test/java/com/google/sps/servlets/PotentialMatchesServletTest.java
+++ b/src/test/java/com/google/sps/servlets/PotentialMatchesServletTest.java
@@ -127,7 +127,6 @@ public class PotentialMatchesServletTest {
     String actualOutput = execute(TEST_USER_1_ID);
 
     assertThat(actualOutput).isEqualTo(NO_POTENTIAL_MATCH_RESULT);
-    assertMatchInfoInDatastore(TEST_USER_1_ID, null);
   }
 
   /**
@@ -148,15 +147,13 @@ public class PotentialMatchesServletTest {
     String actualOutput = execute(TEST_USER_2_ID);
     
     assertThat(actualOutput).isEqualTo(NO_POTENTIAL_MATCH_RESULT);
-    assertMatchInfoInDatastore(TEST_USER_2_ID, null);
   }
 
   /**
   * Tests scenario with three users where User 1 is friends with User 2 and User 3,
   * and User 2 and 3 are only friends with User 1. 
   *
-  * <p>This should return that the first potential match for User 2 is User 3, and
-  * then it should show that there is no second potential match.
+  * <p>This should return that the first potential match for User 2 is User 3.
   */
   @Test
   public void threeUsersOneMutualConnection() throws Exception {
@@ -174,21 +171,13 @@ public class PotentialMatchesServletTest {
     String actualOutput1 = execute(TEST_USER_2_ID);
 
     assertThat(actualOutput1).isEqualTo(TEST_USER_3_ID);
-    assertMatchInfoInDatastore(TEST_USER_2_ID, null);
-
-    String actualOutput2 = execute(TEST_USER_2_ID);
-
-    assertThat(actualOutput2).isEqualTo(NO_POTENTIAL_MATCH_RESULT);
-    assertMatchInfoInDatastore(TEST_USER_2_ID, null);
   }
 
   /**
   * Tests scenario with four users where User 1 is friends with User 2, 3, and 4.
   * Users 2, 3, and 4 are only friends with User 1.
   *
-  * <p>This should return that the first potential match for User 4 is either User 2 or 3 and
-  * that the second one is the other of the two, and then it should show that there is no
-  * third potential match.
+  * <p>This should return that the first potential match for User 4 is either User 2 or 3.
   */
   @Test
   public void fourUsersOneMutualConnection() throws Exception {
@@ -206,22 +195,9 @@ public class PotentialMatchesServletTest {
     addTestUserEntityToDatastore(datastore, TEST_USER_4_ID, TEST_USER_4_NAME,
       TEST_USER_4_EMAIL, TEST_USER_4_BIO, testUser4FriendsList);
 
-    String actualOutput1 = execute(TEST_USER_4_ID);
+    String actualOutput = execute(TEST_USER_4_ID);
 
-    String expectedSecondOutput = actualOutput1.equals(TEST_USER_2_ID) ? TEST_USER_3_ID : TEST_USER_2_ID;
-
-    assertThat(actualOutput1).isIn(Arrays.asList(TEST_USER_2_ID, TEST_USER_3_ID));
-    assertMatchInfoInDatastore(TEST_USER_4_ID, Arrays.asList(expectedSecondOutput));
-
-    String actualOutput2 = execute(TEST_USER_4_ID);
-
-    assertThat(actualOutput2).isEqualTo(expectedSecondOutput);
-    assertMatchInfoInDatastore(TEST_USER_4_ID, null);
-
-    String actualOutput3 = execute(TEST_USER_4_ID);
-
-    assertThat(actualOutput3).isEqualTo(NO_POTENTIAL_MATCH_RESULT);
-    assertMatchInfoInDatastore(TEST_USER_4_ID, null);
+    assertThat(actualOutput).isIn(Arrays.asList(TEST_USER_2_ID, TEST_USER_3_ID));
   }
 
   /**


### PR DESCRIPTION
### What is a quick description of the change?

- Change the PotentialMatchesServlet to not remove the next potential match id from a user's list of potential matches

- Change the MatchDecisionsServlet to remove the next potential match id from a user's list of potential matches

- Update the PotentialMatchesServlet tests to not test updates to a list of potential matches

- Update the MatchDecisionsServlet test to test that the list of potential matches is getting updated

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [ x ] Test written/updating
- [ x ] Tests passing
- [ x ] Coding style (indentation, etc)
