### PR TITLE
add mutual friends when the user has no image

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -81,7 +81,7 @@ function displayPotentialMatchInfo(pmID) {
       }
       if (numPhotos === 0) {
         const noImageElement = createImgElement("images/no_image.png");
-        const noImageSlideshowElement = createSlideshowElement(noImageElement, "carousel-item active", name, bio);
+        const noImageSlideshowElement = createSlideshowElement(noImageElement, "carousel-item active", name, bio, mutualFriends);
         carouselContainer.appendChild(noImageSlideshowElement);
       }
       addIndicators(numPhotos);


### PR DESCRIPTION
### What is a quick description of the change?

Mutual Friends weren't showing up when there was no image for the user, so I added that into the function call
### Is this fixing an issue?

none

### Are there more details that are relevant?

none
### Check lists (check `x` in `[ ]` of list items)

- [  ] Test written/updating
- [x  ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.

passing manual tests

### Any additional comments?

